### PR TITLE
ci(release): add release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,54 @@
+name: release-please
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
+      path: ${{ steps.release.outputs.path }}
+
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: react-penrose-menu
+          # Remove the following flags when the first major version has released
+          bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
+
+  publish:
+    if: ${{ needs.create-release.outputs.release_created }}
+    needs: create-release
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/react-penrose-menu
+
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v3
+
+      - name: Setup node env 🏗
+        id: setup
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies 👨🏻‍💻
+        run: yarn install --frozen-lockfile --immutable
+
+      - name: Publish to npm 📩
+        id: npm-publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description

Introduces the release-please workflow by Google for automated release management. The workflow analyzes the commits (conventional commits required) and creates releases based on them. Once a fix or feat commit is present the process is triggered and a Release PR will be created. It increases the version number in the `package.json` itself, generates a `CHANGELOG.md`, and creates a GitHub-Release.

Currently, the configuration includes two flags to improve version handling in the phase before the first major release and should be removed once the first major release will be released:
```yml
bump-minor-pre-major: true
bump-patch-for-minor-pre-major: true
```

Fixes #3

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
